### PR TITLE
Update the runtime version to from 24.08 to 25.08, and more

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/com.identicalsoftware.anagramarama.yaml
+++ b/com.identicalsoftware.anagramarama.yaml
@@ -1,6 +1,6 @@
 app-id: com.identicalsoftware.anagramarama
 runtime: org.freedesktop.Platform
-runtime-version: 24.08
+runtime-version: 25.08
 sdk: org.freedesktop.Sdk
 command: anagramarama
 rename-icon: anagramarama
@@ -14,6 +14,7 @@ finish-args:
   - --socket=pulseaudio
 
 modules:
+  - shared-modules/SDL2/SDL2_image.json
   - name: libjansson
     buildsystem: cmake-ninja
     sources:
@@ -27,6 +28,8 @@ modules:
 
   - name: libgamerzilla
     buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
     sources:
       - type: git
         url: https://github.com/dulsi/libgamerzilla.git

--- a/com.identicalsoftware.anagramarama.yaml
+++ b/com.identicalsoftware.anagramarama.yaml
@@ -41,6 +41,8 @@ modules:
 
   - name: anagramarama
     buildsystem: cmake-ninja
+    license-files:
+      - gpl.txt
     sources:
       - type: git
         url: https://github.com/dulsi/anagramarama.git

--- a/com.identicalsoftware.anagramarama.yaml
+++ b/com.identicalsoftware.anagramarama.yaml
@@ -12,7 +12,13 @@ finish-args:
   - --share=ipc
   - --socket=x11
   - --socket=pulseaudio
-
+cleanup:
+  - /include
+  - /lib/cmake
+  - /lib/pkgconfig
+  - /share/man
+  - /share/vala
+  - '*.a'
 modules:
   - shared-modules/SDL2/SDL2_image.json
   - name: libjansson


### PR DESCRIPTION
- Update the runtime version to 25.08
- Use the required SDL2_image module from the shared-modules
- Fix build error
- Fix missing license file
- Remove development-related files to reduce the Flatpak size